### PR TITLE
Update SDK to version 1.0.0-alpha4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ rebar3 compile
 
 ## Run
 
-You'll need to put your SDK key in `hello_erlang_server.erl` in the `init()` callback.
-
 ```bash
+export LD_SDK_KEY=YOUR_SDK_KEY
 rebar3 shell
 ```
 
 ```erlang
-hello_erlang_server:get(<<"YOUR_KEY">>, "YOUR_FALLBACK_VALUE", <<"YOUR_USER_KEY">>).
+hello_erlang_server:get(<<"FLAG_KEY">>, "FALLBACK_VALUE", <<"USER_KEY">>).
 ```

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-	{eld, {git, "https://github.com/launchdarkly/erlang-server-sdk", {tag, "1.0.0-alpha3"}}}
+	{eld, {git, "https://github.com/launchdarkly/erlang-server-sdk", {tag, "1.0.0-alpha4"}}}
 ]}.
 
 {shell, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.6.0">>},3},
  {<<"eld">>,
   {git,"https://github.com/launchdarkly/erlang-server-sdk",
-       {ref,"bd75a0b8ddcec8de453720d3a4b5c7092391b876"}},
+       {ref,"c56938943736a6102d23e9fe09bb1c0c1bc8f4cd"}},
   0},
  {<<"gun">>,{pkg,<<"gun">>,<<"1.3.1">>},2},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.9.0">>},1},

--- a/src/hello_erlang_server.erl
+++ b/src/hello_erlang_server.erl
@@ -17,7 +17,7 @@ get(Key, Fallback, User) -> gen_server:call(?MODULE, {get, Key, Fallback, User})
 % gen_server callbacks
 
 init(_Args) ->
-  eld:start_instance("YOUR_SDK_KEY"),
+  eld:start_instance(os:getenv("LD_SDK_KEY")),
   {ok, []}.
 
 handle_call({get, Key, Fallback, User}, _From, State) ->


### PR DESCRIPTION
Also updates the app to grab the SDK key from the environment variable, matching the [hello-elixir](https://github.com/launchdarkly/hello-elixir) example.